### PR TITLE
[Bugfix] Fixed authentication user flow when user cancels provider login

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -76,7 +76,15 @@ export const auth = betterAuth({
       }
     }),
   },
-})
+  onAPIError: {
+		throw: true,
+		onError: (error, ctx) => {
+			// Custom error handling
+			console.error("Auth error:", error);
+		},
+		errorURL: "/sign-in",
+	},
+});
 
 export type Session = typeof auth.$Infer.Session;
 export type User = typeof auth.$Infer.Session.user;


### PR DESCRIPTION
# Description

Fixed authentication user flow when user cancels OAuth provider login by implementing proper error handling and redirection.

## Problem

Previously, when users cancelled OAuth authentication (Google/GitHub login), they would encounter a poor user experience with unclear error states and no feedback about what happened.

## Solution

### Backend Changes (`auth.ts`)
- Added `onAPIError` configuration with proper error handling
- Implemented custom error logging for debugging
- Set `errorURL: "/sign-in"` to redirect users back to sign-in page on auth errors
- Enabled `throw: true` to ensure errors are properly propagated

### Frontend Changes (Sign-in Form)
- Added `useEffect` to detect and handle OAuth errors from URL search parameters
- Implemented user-friendly error messages for different error types:
  - `access_denied` → "Authentication was cancelled" 
  - Other errors → Formatted error descriptions
- Added automatic URL cleanup to remove error parameters after display
- Enhanced error UI styling for better visibility

## Testing

- Cancel Google OAuth flow → Shows "Authentication was cancelled" message
- Cancel GitHub OAuth flow → Shows appropriate error message  
- URL parameters are cleaned up after error display
- Normal authentication flows still work as expected

## Type of Change

- Bug fix (non-breaking change which fixes an issue)
- UI/UX improvement